### PR TITLE
Improve performance for `Uint8Array`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,26 @@
 export default function stripFinalNewline(input) {
-	const LF = typeof input === 'string' ? '\n' : '\n'.codePointAt();
-	const CR = typeof input === 'string' ? '\r' : '\r'.codePointAt();
-
-	if (input.at(-1) === LF) {
-		input = input.slice(0, -1);
+	if (typeof input === 'string') {
+		return stripFinalNewlineString(input);
 	}
 
-	if (input.at(-1) === CR) {
-		input = input.slice(0, -1);
+	if (!ArrayBuffer.isView(input) || input.BYTES_PER_ELEMENT !== 1) {
+		throw new Error('Input must be a string, a Buffer or a Uint8Array');
 	}
 
-	return input;
+	return stripFinalNewlineBinary(input);
 }
+
+const stripFinalNewlineString = input =>
+	input.at(-1) === LF ?
+		input.slice(0, input.at(-2) === CR ? -2 : -1) :
+		input;
+
+const stripFinalNewlineBinary = input =>
+	input.at(-1) === LF_BINARY ?
+		input.subarray(0, input.at(-2) === CR_BINARY ? -2 : -1) :
+		input;
+
+const LF = '\n';
+const LF_BINARY = LF.codePointAt(0);
+const CR = '\r';
+const CR_BINARY = CR.codePointAt(0);

--- a/index.js
+++ b/index.js
@@ -11,14 +11,14 @@ export default function stripFinalNewline(input) {
 }
 
 const stripFinalNewlineString = input =>
-	input.at(-1) === LF ?
-		input.slice(0, input.at(-2) === CR ? -2 : -1) :
-		input;
+	input.at(-1) === LF
+		? input.slice(0, input.at(-2) === CR ? -2 : -1)
+		: input;
 
 const stripFinalNewlineBinary = input =>
-	input.at(-1) === LF_BINARY ?
-		input.subarray(0, input.at(-2) === CR_BINARY ? -2 : -1) :
-		input;
+	input.at(-1) === LF_BINARY
+		? input.subarray(0, input.at(-2) === CR_BINARY ? -2 : -1)
+		: input;
 
 const LF = '\n';
 const LF_BINARY = LF.codePointAt(0);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export default function stripFinalNewline(input) {
 	}
 
 	if (!ArrayBuffer.isView(input) || input.BYTES_PER_ELEMENT !== 1) {
-		throw new Error('Input must be a string, a Buffer or a Uint8Array');
+		throw new Error('Input must be a string or a Uint8Array');
 	}
 
 	return stripFinalNewlineBinary(input);

--- a/readme.md
+++ b/readme.md
@@ -21,18 +21,14 @@ stripFinalNewline('foo\nbar\n\n');
 const uint8Array = new TextEncoder().encode('foo\nbar\n\n')
 new TextDecoder().decode(stripFinalNewline(uint8Array));
 //=> 'foo\nbar\n'
-
-const uint8Array = new TextEncoder().encode('foo\nbar\n\n')
-new TextDecoder().decode(stripFinalNewline(uint8Array));
-//=> 'foo\nbar\n'
 ```
 
 ## Performance
 
-When using a `Buffer` or an `Uint8Array`, the original value is referenced, not copied. This is much more efficient, requires almost no memory, and remains milliseconds fast even on very large inputs.
+When using an `Uint8Array`, the original value is referenced, not copied. This is much more efficient, requires almost no memory, and remains milliseconds fast even on very large inputs.
 
 If you'd like to ensure that modifying the return value does not also modify the value passed as input, please use `.slice()`.
 
 ```js
-const value = stripFinalNewline(Buffer.from('foo\nbar\n\n')).slice();
+const value = new TextDecoder().decode(stripFinalNewline(uint8Array)).slice();
 ```

--- a/readme.md
+++ b/readme.md
@@ -21,4 +21,18 @@ stripFinalNewline('foo\nbar\n\n');
 const uint8Array = new TextEncoder().encode('foo\nbar\n\n')
 new TextDecoder().decode(stripFinalNewline(uint8Array));
 //=> 'foo\nbar\n'
+
+const uint8Array = new TextEncoder().encode('foo\nbar\n\n')
+new TextDecoder().decode(stripFinalNewline(uint8Array));
+//=> 'foo\nbar\n'
+```
+
+## Performance
+
+When using a `Buffer` or an `Uint8Array`, the original value is referenced, not copied. This is much more efficient, requires almost no memory, and remains milliseconds fast even on very large inputs.
+
+If you'd like to ensure that modifying the return value does not also modify the value passed as input, please use `.slice()`.
+
+```js
+const value = stripFinalNewline(Buffer.from('foo\nbar\n\n')).slice();
 ```

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ const inputs = [
 	'foo\n\n\n',
 	'foo\r\n',
 	'foo\r',
-	'foo\n\r\n'
+	'foo\n\r\n',
 ];
 
 const outputs = [
@@ -29,7 +29,7 @@ const outputs = [
 	'foo\n\n',
 	'foo',
 	'foo\r',
-	'foo\n'
+	'foo\n',
 ];
 
 const identity = input => input;

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-import {Buffer} from 'node:buffer';
 import test from 'ava';
 import stripFinalNewline from './index.js';
 
@@ -40,15 +39,6 @@ test('string - LF LF LF', assertStrip, identity, inputs[2], outputs[2]);
 test('string - CR LF', assertStrip, identity, inputs[3], outputs[3]);
 test('string - CR', assertStrip, identity, inputs[4], outputs[4]);
 test('string - LF CR LF', assertStrip, identity, inputs[5], outputs[5]);
-
-const toBuffer = Buffer.from;
-
-test('Buffer - LF', assertStrip, toBuffer, inputs[0], outputs[0]);
-test('Buffer - LF text LF', assertStrip, toBuffer, inputs[1], outputs[1]);
-test('Buffer - LF LF LF', assertStrip, toBuffer, inputs[2], outputs[2]);
-test('Buffer - CR LF', assertStrip, toBuffer, inputs[3], outputs[3]);
-test('Buffer - CR', assertStrip, toBuffer, inputs[4], outputs[4]);
-test('Buffer - LF CR LF', assertStrip, toBuffer, inputs[5], outputs[5]);
 
 const textEncoder = new TextEncoder();
 const toUint8Array = textEncoder.encode.bind(textEncoder);

--- a/test.js
+++ b/test.js
@@ -2,20 +2,60 @@ import {Buffer} from 'node:buffer';
 import test from 'ava';
 import stripFinalNewline from './index.js';
 
-test('string', t => {
-	t.is(stripFinalNewline('foo\n'), 'foo');
-	t.is(stripFinalNewline('foo\nbar\n'), 'foo\nbar');
-	t.is(stripFinalNewline('foo\n\n\n'), 'foo\n\n');
-	t.is(stripFinalNewline('foo\r\n'), 'foo');
-	t.is(stripFinalNewline('foo\r'), 'foo');
-	t.is(stripFinalNewline('foo\n\r\n'), 'foo\n');
-});
+const invalidType = async (t, input) => {
+	t.throws(() => stripFinalNewline(input), {message: /Input must be/});
+};
 
-test('buffer', t => {
-	t.is(stripFinalNewline(Buffer.from('foo\n')).toString(), 'foo');
-	t.is(stripFinalNewline(Buffer.from('foo\nbar\n')).toString(), 'foo\nbar');
-	t.is(stripFinalNewline(Buffer.from('foo\n\n\n').toString()), 'foo\n\n');
-	t.is(stripFinalNewline(Buffer.from('foo\r\n')).toString(), 'foo');
-	t.is(stripFinalNewline(Buffer.from('foo\r')).toString(), 'foo');
-	t.is(stripFinalNewline(Buffer.from('foo\n\r\n')).toString(), 'foo\n');
-});
+test('Invalid type - boolean', invalidType, true);
+test('Invalid type - DataView', invalidType, new DataView(new ArrayBuffer(0)));
+test('Invalid type - Uint16Array', invalidType, new Uint16Array(new ArrayBuffer(0)));
+
+const assertStrip = async (t, convert, input, output) => {
+	t.deepEqual(stripFinalNewline(convert(input)), convert(output));
+};
+
+const inputs = [
+	'foo\n',
+	'foo\nbar\n',
+	'foo\n\n\n',
+	'foo\r\n',
+	'foo\r',
+	'foo\n\r\n'
+];
+
+const outputs = [
+	'foo',
+	'foo\nbar',
+	'foo\n\n',
+	'foo',
+	'foo\r',
+	'foo\n'
+];
+
+const identity = input => input;
+
+test('string - LF', assertStrip, identity, inputs[0], outputs[0]);
+test('string - LF text LF', assertStrip, identity, inputs[1], outputs[1]);
+test('string - LF LF LF', assertStrip, identity, inputs[2], outputs[2]);
+test('string - CR LF', assertStrip, identity, inputs[3], outputs[3]);
+test('string - CR', assertStrip, identity, inputs[4], outputs[4]);
+test('string - LF CR LF', assertStrip, identity, inputs[5], outputs[5]);
+
+const toBuffer = Buffer.from;
+
+test('Buffer - LF', assertStrip, toBuffer, inputs[0], outputs[0]);
+test('Buffer - LF text LF', assertStrip, toBuffer, inputs[1], outputs[1]);
+test('Buffer - LF LF LF', assertStrip, toBuffer, inputs[2], outputs[2]);
+test('Buffer - CR LF', assertStrip, toBuffer, inputs[3], outputs[3]);
+test('Buffer - CR', assertStrip, toBuffer, inputs[4], outputs[4]);
+test('Buffer - LF CR LF', assertStrip, toBuffer, inputs[5], outputs[5]);
+
+const textEncoder = new TextEncoder();
+const toUint8Array = textEncoder.encode.bind(textEncoder);
+
+test('Uint8Array - LF', assertStrip, toUint8Array, inputs[0], outputs[0]);
+test('Uint8Array - LF text LF', assertStrip, toUint8Array, inputs[1], outputs[1]);
+test('Uint8Array - LF LF LF', assertStrip, toUint8Array, inputs[2], outputs[2]);
+test('Uint8Array - CR LF', assertStrip, toUint8Array, inputs[3], outputs[3]);
+test('Uint8Array - CR', assertStrip, toUint8Array, inputs[4], outputs[4]);
+test('Uint8Array - LF CR LF', assertStrip, toUint8Array, inputs[5], outputs[5]);


### PR DESCRIPTION
This PR improves the performance, turning the time complexity from `O(n)` to `O(1)` for `Buffer`.

This PR also adds explicit support for `Uint8Array`s, although this was (maybe accidentally) already supported.

The performance improvement is done by using `.subarray()` instead of `.slice()`, i.e. re-using the underlying `ArrayBuffer` instead of copying. On big inputs, the difference is huge. On my machine, an input of a few MBs would take ~30ms with the new logic and ~3000ms with the previous one.

One gotcha is that, when using `Buffer`/`Uint8Array` (not `string`), the return value now shares the same the underlying `ArrayBuffer` as the value passed as argument. It is not a copy anymore. So modifying the return value will also modify that argument. IMHO in most cases, this should not be a problem. It could even be sometimes desirable. But if the user does need a copy, then they can call `.slice()` on the return value.

Another breaking change is that this PR removes the support for stripping `\r` at the end of inputs (as opposed to `\r\n` and `\n`. I am not sure whether stripping `\r` was intentional? I could be wrong, but I believe `\r` is never used as a newline on any modern OS (although some OSes in the 80s might have used it). However, if you want me to restore that behavior, please let me know.