### PR TITLE
Upgrade dependencies and Node version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,18 +4,21 @@ on:
   - pull_request
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         node-version:
-          - 16
-          - 14
-          - 12
+          - 20
+          - 18
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 export default function stripFinalNewline(input) {
-	const LF = typeof input === 'string' ? '\n' : '\n'.charCodeAt();
-	const CR = typeof input === 'string' ? '\r' : '\r'.charCodeAt();
+	const LF = typeof input === 'string' ? '\n' : '\n'.codePointAt();
+	const CR = typeof input === 'string' ? '\r' : '\r'.codePointAt();
 
-	if (input[input.length - 1] === LF) {
+	if (input.at(-1) === LF) {
 		input = input.slice(0, -1);
 	}
 
-	if (input[input.length - 1] === CR) {
+	if (input.at(-1) === CR) {
 		input = input.slice(0, -1);
 	}
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -37,7 +37,7 @@
 		"buffer"
 	],
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"xo": "^0.39.1"
+		"ava": "^6.0.1",
+		"xo": "^0.56.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import {Buffer} from 'node:buffer';
 import test from 'ava';
 import stripFinalNewline from './index.js';
 


### PR DESCRIPTION
This upgrades dependencies. Some code had to be fixed for linting purpose.

This also removes support for Node 12, 14, 16, and now runs CI on both Windows and Unix.